### PR TITLE
changing bower.json name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-    "name": "Bootstrap Offcanvas Navigation",
+    "name": "bootstrap-offcanvas-navigation",
     "version": "1.0.2",
     "main": ["dist/bootstrap-offcanvas-navigation.min.js", "dist/bootstrap-offcanvas-navigation.min.css"],
     "devDependencies": {


### PR DESCRIPTION
When trying to use the grunt bower task, there's an error with the name in bower.json. This fixes it.
